### PR TITLE
Add 3D trees over an ordination

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -13,6 +13,7 @@ import(scatterplot3d)
 export(ordicluster3d,
        ordiplot3d,
        ordirgl,
+       orglcluster,
        orglpoints,
        orglsegments,
        orglspider,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -10,7 +10,8 @@ import(scatterplot3d)
   importFrom("stats", "weighted.mean", "weights")
 
 ## export what we got
-export(ordiplot3d,
+export(ordicluster3d,
+       ordiplot3d,
        ordirgl,
        orglpoints,
        orglsegments,

--- a/R/ordicluster3d.R
+++ b/R/ordicluster3d.R
@@ -1,5 +1,6 @@
 `ordicluster3d` <-
-    function(ord, cluster, display = "sites", choices = c(1,2), ...)
+    function(ord, cluster, display = "sites", choices = c(1,2), pcol = 1,
+             col = 1, type = "p", ...)
 {
     ## ordination scores in 2d: leaves
     ord <- scores(ord, choices = choices, display = display, ...)
@@ -13,7 +14,10 @@
     xyz <- cbind(x, y, "height" = cluster$height)
     ## set up frame
     pl <- scatterplot3d(rbind(ord, xyz), type = "n")
-    pl$points3d(ord, ...)
+    if (type == "p")
+        pl$points3d(ord, col = pcol, ...)
+    else if (type == "t")
+        text(pl$xyz.convert(ord), rownames(ord), col = pcol, ...)
     ## project leaves and nodes to 2d
     leaf <- pl$xyz.convert(ord)
     node <- pl$xyz.convert(xyz)
@@ -24,10 +28,12 @@
          for (j in 1:2)
              if (merge[i,j] < 0)
                  segments(node$x[i], node$y[i],
-                          leaf$x[-merge[i,j]], leaf$y[-merge[i,j]], ...)
+                          leaf$x[-merge[i,j]], leaf$y[-merge[i,j]],
+                          col = col, ...)
              else
                  segments(node$x[i], node$y[i],
-                          node$x[merge[i,j]], node$y[merge[i,j]], ...)
+                          node$x[merge[i,j]], node$y[merge[i,j]],
+                          col = col, ...)
 
     pl$nodes <- node
     pl$leaves <- leaf
@@ -35,7 +41,8 @@
 }
 
 `orglcluster` <-
-    function(ord, cluster, display = "sites", choices = c(1, 2), ...)
+    function(ord, cluster, display = "sites", choices = c(1, 2),
+             pcol = "red", col = "blue", type = "p", ...)
 {
     p <- cbind(scores(ord, choices = choices, display = display, ...), 0)
     if (ncol(p) != 3)
@@ -48,16 +55,18 @@
     z <- mean(c(diff(range(x)), diff(range(y))))/diff(range(z)) * z
     ## plot
     rgl.clear()
-    rgl.points(p, col=2)
+    if (type == "p")
+        rgl.points(p, col = pcol, ...)
+    else if (type == "t")
+        rgl.texts(p, text = rownames(p), col = pcol, ...)
     for (i in seq_len(nrow(merge)))
         for(j in 1:2)
             if (merge[i,j] < 0)
                 rgl.lines(c(x[i], p[-merge[i,j],1]),
                           c(y[i], p[-merge[i,j],2]),
-                          c(z[i], 0), col=4)
+                          c(z[i], 0), col=col)
             else
                 rgl.lines(c(x[i], x[merge[i,j]]),
                           c(y[i], y[merge[i,j]]),
-                          c(z[i], z[merge[i,j]]), col=4)
+                          c(z[i], z[merge[i,j]]), col=col)
 }
-    

--- a/R/ordicluster3d.R
+++ b/R/ordicluster3d.R
@@ -35,9 +35,11 @@
 }
 
 `orglcluster` <-
-    function(ord, cluster, ...)
+    function(ord, cluster, choices = c(1, 2), display = "sites", ...)
 {
-    p <- cbind(scores(ord, ...), 0)
+    p <- cbind(scores(ord, choices = choices, display = display, ...), 0)
+    if (ncol(p) != 3)
+        stop(gettextf("needs 2D ordination plane, but got %d", ncol(p)-1))
     x <- reorder(cluster, p[,1], agglo.FUN = "mean")$value
     y <- reorder(cluster, p[,2], agglo.FUN = "mean")$value
     z <- cluster$height

--- a/R/ordicluster3d.R
+++ b/R/ordicluster3d.R
@@ -1,0 +1,35 @@
+`ordicluster3d` <-
+    function(ord, cluster, choices = c(1,2), display = "sites", ...)
+{
+    ## ordination scores in 2d: leaves
+    ord <- scores(ord, choices = choices, display = display, ...)
+    ## pad z-axis to zeros
+    if (ncol(ord) != 2)
+        stop(gettextf("needs plane in 2d, got %d", ncol(ord)))
+    ord <- cbind(ord, 0)
+    ## get coordinates of internal nodes with vegan:::reorder.hclust
+    x <- reorder(cluster, ord[,1], agglo.FUN = "mean")$value
+    y <- reorder(cluster, ord[,2], agglo.FUN = "mean")$value
+    xyz <- cbind(x, y, "height" = cluster$height)
+    ## set up frame
+    pl <- scatterplot3d(rbind(ord, xyz), type = "n")
+    pl$points3d(ord, ...)
+    ## project leaves and nodes to 2d
+    leaf <- pl$xyz.convert(ord)
+    node <- pl$xyz.convert(xyz)
+    ## two lines from each node down, either to a leaf or to an
+    ## internal node
+    merge <- cluster$merge
+    for (i in seq_len(nrow(merge)))
+         for (j in 1:2)
+             if (merge[i,j] < 0)
+                 segments(node$x[i], node$y[i],
+                          leaf$x[-merge[i,j]], leaf$y[-merge[i,j]], ...)
+             else
+                 segments(node$x[i], node$y[i],
+                          node$x[merge[i,j]], node$y[merge[i,j]], ...)
+
+    pl$nodes <- node
+    pl$leaves <- leaf
+    invisible(pl)
+}

--- a/R/ordicluster3d.R
+++ b/R/ordicluster3d.R
@@ -33,3 +33,27 @@
     pl$leaves <- leaf
     invisible(pl)
 }
+
+`orglcluster` <-
+    function(ord, cluster, ...)
+{
+    p <- cbind(scores(ord, ...), 0)
+    x <- reorder(cluster, p[,1], agglo.FUN = "mean")$value
+    y <- reorder(cluster, p[,2], agglo.FUN = "mean")$value
+    z <- cluster$height
+    merge <- cluster$merge
+    ## plot
+    rgl.clear()
+    rgl.points(p, col=2)
+    for (i in seq_len(nrow(merge)))
+        for(j in 1:2)
+            if (merge[i,j] < 0)
+                rgl.lines(c(x[i], p[-merge[i,j],1]),
+                          c(y[i], p[-merge[i,j],2]),
+                          c(z[i], 0), col=4)
+            else
+                rgl.lines(c(x[i], x[merge[i,j]]),
+                          c(y[i], y[merge[i,j]]),
+                          c(z[i], z[merge[i,j]]), col=4)
+}
+    

--- a/R/ordicluster3d.R
+++ b/R/ordicluster3d.R
@@ -44,6 +44,8 @@
     y <- reorder(cluster, p[,2], agglo.FUN = "mean")$value
     z <- cluster$height
     merge <- cluster$merge
+    ## adjust height
+    z <- mean(c(diff(range(x)), diff(range(y))))/diff(range(z)) * z
     ## plot
     rgl.clear()
     rgl.points(p, col=2)

--- a/R/ordicluster3d.R
+++ b/R/ordicluster3d.R
@@ -8,6 +8,8 @@
     if (ncol(ord) != 2)
         stop(gettextf("needs plane in 2d, got %d", ncol(ord)))
     ord <- cbind(ord, 0)
+    if (!inherits(cluster, "hclust")) # works only with hclust
+        cluster <- as.hclust(cluster) # or object that can be converted
     ## get coordinates of internal nodes with vegan:::reorder.hclust
     x <- reorder(cluster, ord[,1], agglo.FUN = "mean")$value
     y <- reorder(cluster, ord[,2], agglo.FUN = "mean")$value
@@ -47,6 +49,8 @@
     p <- cbind(scores(ord, choices = choices, display = display, ...), 0)
     if (ncol(p) != 3)
         stop(gettextf("needs 2D ordination plane, but got %d", ncol(p)-1))
+    if (!inherits(cluster, "hclust"))
+        cluster <- as.hclust(cluster)
     x <- reorder(cluster, p[,1], agglo.FUN = "mean")$value
     y <- reorder(cluster, p[,2], agglo.FUN = "mean")$value
     z <- cluster$height

--- a/R/ordicluster3d.R
+++ b/R/ordicluster3d.R
@@ -1,6 +1,6 @@
 `ordicluster3d` <-
-    function(ord, cluster, display = "sites", choices = c(1,2), pcol = 1,
-             col = 1, type = "p", ...)
+    function(ord, cluster, prune = 0, display = "sites", choices = c(1,2),
+             pcol = 1, col = 1, type = "p", ...)
 {
     ## ordination scores in 2d: leaves
     ord <- scores(ord, choices = choices, display = display, ...)
@@ -26,7 +26,7 @@
     ## two lines from each node down, either to a leaf or to an
     ## internal node
     merge <- cluster$merge
-    for (i in seq_len(nrow(merge)))
+    for (i in seq_len(nrow(merge) - prune))
          for (j in 1:2)
              if (merge[i,j] < 0)
                  segments(node$x[i], node$y[i],
@@ -43,7 +43,7 @@
 }
 
 `orglcluster` <-
-    function(ord, cluster, display = "sites", choices = c(1, 2),
+    function(ord, cluster, prune = 0, display = "sites", choices = c(1, 2),
              pcol = "red", col = "blue", type = "p", ...)
 {
     p <- cbind(scores(ord, choices = choices, display = display, ...), 0)
@@ -63,7 +63,7 @@
         rgl.points(p, col = pcol, ...)
     else if (type == "t")
         rgl.texts(p, text = rownames(p), col = pcol, ...)
-    for (i in seq_len(nrow(merge)))
+    for (i in seq_len(nrow(merge) - prune))
         for(j in 1:2)
             if (merge[i,j] < 0)
                 rgl.lines(c(x[i], p[-merge[i,j],1]),

--- a/R/ordicluster3d.R
+++ b/R/ordicluster3d.R
@@ -1,6 +1,6 @@
 `ordicluster3d` <-
     function(ord, cluster, prune = 0, display = "sites", choices = c(1,2),
-             pcol = 1, col = 1, type = "p", ...)
+             col = "blue", type = "p", ...)
 {
     ## ordination scores in 2d: leaves
     ord <- scores(ord, choices = choices, display = display, ...)
@@ -14,12 +14,19 @@
     x <- reorder(cluster, ord[,1], agglo.FUN = "mean")$value
     y <- reorder(cluster, ord[,2], agglo.FUN = "mean")$value
     xyz <- cbind(x, y, "height" = cluster$height)
+    ## make line colour the mean of point colours
+    col <- rep(col, nrow(ord))
+    lcol <- col2rgb(col)/255
+    r <- reorder(cluster, lcol[1,], agglo.FUN = "mean")$value
+    g <- reorder(cluster, lcol[2,], agglo.FUN = "mean")$value
+    b <- reorder(cluster, lcol[3,], agglo.FUN = "mean")$value
+    lcol <- rgb(r, g, b)
     ## set up frame
     pl <- scatterplot3d(rbind(ord, xyz), type = "n")
     if (type == "p")
-        pl$points3d(ord, col = pcol, ...)
+        pl$points3d(ord, col = col, ...)
     else if (type == "t")
-        text(pl$xyz.convert(ord), rownames(ord), col = pcol, ...)
+        text(pl$xyz.convert(ord), rownames(ord), col = col, ...)
     ## project leaves and nodes to 2d
     leaf <- pl$xyz.convert(ord)
     node <- pl$xyz.convert(xyz)
@@ -31,11 +38,11 @@
              if (merge[i,j] < 0)
                  segments(node$x[i], node$y[i],
                           leaf$x[-merge[i,j]], leaf$y[-merge[i,j]],
-                          col = col, ...)
+                          col = col[-merge[i,j]], ...)
              else
                  segments(node$x[i], node$y[i],
                           node$x[merge[i,j]], node$y[merge[i,j]],
-                          col = col, ...)
+                          col = lcol[merge[i,j]], ...)
 
     pl$nodes <- node
     pl$leaves <- leaf
@@ -44,7 +51,7 @@
 
 `orglcluster` <-
     function(ord, cluster, prune = 0, display = "sites", choices = c(1, 2),
-             pcol = "red", col = "blue", type = "p", ...)
+             col = "blue", type = "p", ...)
 {
     p <- cbind(scores(ord, choices = choices, display = display, ...), 0)
     if (ncol(p) != 3)
@@ -57,20 +64,27 @@
     merge <- cluster$merge
     ## adjust height
     z <- mean(c(diff(range(x)), diff(range(y))))/diff(range(z)) * z
+    ## make line colour the mean of point colours
+    col <- rep(col, length = nrow(p))
+    lcol <- col2rgb(col)/255
+    r <- reorder(cluster, lcol[1,], agglo.FUN = "mean")$value
+    g <- reorder(cluster, lcol[2,], agglo.FUN = "mean")$value
+    b <- reorder(cluster, lcol[3,], agglo.FUN = "mean")$value
+    lcol <- rgb(r, g, b)
     ## plot
     rgl.clear()
     if (type == "p")
-        rgl.points(p, col = pcol, ...)
+        rgl.points(p, col = col, ...)
     else if (type == "t")
-        rgl.texts(p, text = rownames(p), col = pcol, ...)
+        rgl.texts(p, text = rownames(p), col = col, ...)
     for (i in seq_len(nrow(merge) - prune))
         for(j in 1:2)
             if (merge[i,j] < 0)
                 rgl.lines(c(x[i], p[-merge[i,j],1]),
                           c(y[i], p[-merge[i,j],2]),
-                          c(z[i], 0), col=col)
+                          c(z[i], 0), col = col[-merge[i,j]])
             else
                 rgl.lines(c(x[i], x[merge[i,j]]),
                           c(y[i], y[merge[i,j]]),
-                          c(z[i], z[merge[i,j]]), col=col)
+                          c(z[i], z[merge[i,j]]), col = lcol[merge[i,j]])
 }

--- a/R/ordicluster3d.R
+++ b/R/ordicluster3d.R
@@ -1,5 +1,5 @@
 `ordicluster3d` <-
-    function(ord, cluster, choices = c(1,2), display = "sites", ...)
+    function(ord, cluster, display = "sites", choices = c(1,2), ...)
 {
     ## ordination scores in 2d: leaves
     ord <- scores(ord, choices = choices, display = display, ...)
@@ -35,7 +35,7 @@
 }
 
 `orglcluster` <-
-    function(ord, cluster, choices = c(1, 2), display = "sites", ...)
+    function(ord, cluster, display = "sites", choices = c(1, 2), ...)
 {
     p <- cbind(scores(ord, choices = choices, display = display, ...), 0)
     if (ncol(p) != 3)

--- a/man/ordicluster3d.Rd
+++ b/man/ordicluster3d.Rd
@@ -1,0 +1,56 @@
+\name{ordicluster3d}
+\alias{ordicluster3d}
+
+\title{
+Draw Cluster Tree over an Ordination Plane
+}
+
+\description{
+  Function draws a 3D plot where ordination result is at the bottom
+  plane and and a \code{\link{hclust}} dendrogam is drawn above the
+  plane.
+}
+
+\usage{
+ordicluster3d(ord, cluster, choices = c(1, 2), display = "sites", ...)
+}
+
+\arguments{
+  \item{ord}{
+    An ordination object or an \code{\link[vegan]{ordilplot}} object.}
+
+  \item{cluster}{Result of hierarchic cluster analysis, such as
+    \code{\link{hclust}} or \code{\link[cluster]{agnes}}.}
+
+  \item{choices}{
+    Choice of ordination axes.}
+
+  \item{display}{
+    Ordination scores displayed.}
+
+  \item{\dots}{
+    Arguments passed to \code{\link[vegan]{scores}}, \code{\link{points}} or
+    \code{\link{segments}}.}
+}
+
+\value{
+  Function returns invisibly a
+  \code{\link[scatterplot3d]{scatterplot3d}} result object amended
+  with items \code{leaves} and \code{nodes} that give the projected
+  coordinates of ordination scores and internal nodes.
+}
+
+\author{
+  Jari Oksanen.
+}
+
+\seealso{
+  \code{\link[vegan]{ordicluster}} in \pkg{vegan}.
+}
+\examples{
+  data(dune)
+  d <- vegdist(dune)
+  ordicluster3d(metaMDS(d), hclust(d), pch=16, col="blue")
+}
+
+\keyword{ hplot }

--- a/man/ordicluster3d.Rd
+++ b/man/ordicluster3d.Rd
@@ -13,9 +13,9 @@ Draw Cluster Tree over an Ordination Plane
 }
 
 \usage{
-ordicluster3d(ord, cluster, display = "sites", choices = c(1, 2),
+ordicluster3d(ord, cluster, prune = 0, display = "sites", choices = c(1, 2),
     pcol = 1, col = 1, type = "p", ...)
-orglcluster(ord, cluster, display = "sites", choices = c(1, 2),
+orglcluster(ord, cluster, prune = 0, display = "sites", choices = c(1, 2),
     pcol = "red", col = "blue", type = "p", ...)
 }
 
@@ -25,6 +25,10 @@ orglcluster(ord, cluster, display = "sites", choices = c(1, 2),
 
   \item{cluster}{Result of hierarchic cluster analysis, such as
     \code{\link{hclust}} or \code{\link[cluster]{agnes}}.}
+
+  \item{prune}{Number of upper levels hierarchies removed from the
+    tree. If \code{prune} > 0, tree will be cut into \code{prune + 1}
+    disconnected trees.}
 
   \item{choices}{
     Choice of ordination axes.}

--- a/man/ordicluster3d.Rd
+++ b/man/ordicluster3d.Rd
@@ -17,7 +17,7 @@ ordicluster3d(ord, cluster, choices = c(1, 2), display = "sites", ...)
 
 \arguments{
   \item{ord}{
-    An ordination object or an \code{\link[vegan]{ordilplot}} object.}
+    An ordination object or an \code{\link[vegan]{ordiplot}} object.}
 
   \item{cluster}{Result of hierarchic cluster analysis, such as
     \code{\link{hclust}} or \code{\link[cluster]{agnes}}.}

--- a/man/ordicluster3d.Rd
+++ b/man/ordicluster3d.Rd
@@ -14,7 +14,7 @@ Draw Cluster Tree over an Ordination Plane
 
 \usage{
 ordicluster3d(ord, cluster, choices = c(1, 2), display = "sites", ...)
-orglcluster(ord, cluster, ...)
+orglcluster(ord, cluster, choices = c(1, 2), display = "sites", ...)
 }
 
 \arguments{

--- a/man/ordicluster3d.Rd
+++ b/man/ordicluster3d.Rd
@@ -68,6 +68,11 @@ orglcluster(ord, cluster, display = "sites", choices = c(1, 2),
   data(dune)
   d <- vegdist(dune)
   ordicluster3d(metaMDS(d), hclust(d), pch=16, col="blue")
+  ## orglcluster examples need interaction
+  \dontrun{
+  cl <- hclust(d, "aver")
+  orglcluster(metaMDS(d), cl, pcol = cutree(hclust(d), 3), col="yellow")
+  }
 }
 
 \keyword{ hplot }

--- a/man/ordicluster3d.Rd
+++ b/man/ordicluster3d.Rd
@@ -13,8 +13,8 @@ Draw Cluster Tree over an Ordination Plane
 }
 
 \usage{
-ordicluster3d(ord, cluster, choices = c(1, 2), display = "sites", ...)
-orglcluster(ord, cluster, choices = c(1, 2), display = "sites", ...)
+ordicluster3d(ord, cluster, display = "sites", choices = c(1, 2), ...)
+orglcluster(ord, cluster, display = "sites", choices = c(1, 2), ...)
 }
 
 \arguments{

--- a/man/ordicluster3d.Rd
+++ b/man/ordicluster3d.Rd
@@ -1,5 +1,6 @@
 \name{ordicluster3d}
 \alias{ordicluster3d}
+\alias{orglcluster}
 
 \title{
 Draw Cluster Tree over an Ordination Plane
@@ -13,6 +14,7 @@ Draw Cluster Tree over an Ordination Plane
 
 \usage{
 ordicluster3d(ord, cluster, choices = c(1, 2), display = "sites", ...)
+orglcluster(ord, cluster, ...)
 }
 
 \arguments{
@@ -28,16 +30,22 @@ ordicluster3d(ord, cluster, choices = c(1, 2), display = "sites", ...)
   \item{display}{
     Ordination scores displayed.}
 
-  \item{\dots}{
-    Arguments passed to \code{\link[vegan]{scores}}, \code{\link{points}} or
-    \code{\link{segments}}.}
+  \item{\dots}{ Arguments passed to \code{\link[vegan]{scores}} and
+    graphical functions.}
+}
+
+\details{
+  \code{ordicluster3d} uses \pkg{scatterplot3d} package to draw a
+  static 3D plot of the dendrogram over the ordinaation, and
+  \code{orglcluster} uses \pkg{rgl} to make a dynamic, spinnable plot.
 }
 
 \value{
-  Function returns invisibly a
+  Function \code{ordicluster3d} returns invisibly a
   \code{\link[scatterplot3d]{scatterplot3d}} result object amended
   with items \code{leaves} and \code{nodes} that give the projected
-  coordinates of ordination scores and internal nodes.
+  coordinates of ordination scores and internal nodes. Function
+  \code{orglcluster} returns nothing.
 }
 
 \author{

--- a/man/ordicluster3d.Rd
+++ b/man/ordicluster3d.Rd
@@ -14,9 +14,9 @@ Draw Cluster Tree over an Ordination Plane
 
 \usage{
 ordicluster3d(ord, cluster, prune = 0, display = "sites", choices = c(1, 2),
-    pcol = 1, col = 1, type = "p", ...)
+    col = "blue", type = "p", ...)
 orglcluster(ord, cluster, prune = 0, display = "sites", choices = c(1, 2),
-    pcol = "red", col = "blue", type = "p", ...)
+    col = "blue", type = "p", ...)
 }
 
 \arguments{
@@ -36,9 +36,9 @@ orglcluster(ord, cluster, prune = 0, display = "sites", choices = c(1, 2),
   \item{display}{
     Ordination scores displayed.}
 
-  \item{pcol}{Colour of points or text.}
-
-  \item{col}{Colour of tree segments.}
+  \item{col}{Colour of tree. The colour can be a vector and it is used
+    for the points, text and terminal branches. The colour of internal
+    branches is a mixture of connected leaves.}
 
   \item{type}{Display of leaves: \code{"p"} for points, \code{"t"} for
     item rownames of scores, and \code{"n"} for no display.}
@@ -69,13 +69,15 @@ orglcluster(ord, cluster, prune = 0, display = "sites", choices = c(1, 2),
   \code{\link[vegan]{ordicluster}} in \pkg{vegan}.
 }
 \examples{
-  data(dune)
+  data(dune, dune.env)
   d <- vegdist(dune)
-  ordicluster3d(metaMDS(d), hclust(d), pch=16, col="blue")
-  ## orglcluster examples need interaction
-  \dontrun{
+  m <- metaMDS(d)
   cl <- hclust(d, "aver")
-  orglcluster(metaMDS(d), cl, pcol = cutree(hclust(d), 3), col="yellow")
+  ordicluster3d(m, cl, pch=16, col=cutree(cl, 3))
+  ## orglcluster examples need interaction
+\dontrun{
+  management <- with(dune.env, as.numeric(Management))
+  orglcluster(m, cl, col=management, size = 6)
   }
 }
 

--- a/man/ordicluster3d.Rd
+++ b/man/ordicluster3d.Rd
@@ -13,8 +13,10 @@ Draw Cluster Tree over an Ordination Plane
 }
 
 \usage{
-ordicluster3d(ord, cluster, display = "sites", choices = c(1, 2), ...)
-orglcluster(ord, cluster, display = "sites", choices = c(1, 2), ...)
+ordicluster3d(ord, cluster, display = "sites", choices = c(1, 2),
+    pcol = 1, col = 1, type = "p", ...)
+orglcluster(ord, cluster, display = "sites", choices = c(1, 2),
+    pcol = "red", col = "blue", type = "p", ...)
 }
 
 \arguments{
@@ -29,6 +31,13 @@ orglcluster(ord, cluster, display = "sites", choices = c(1, 2), ...)
 
   \item{display}{
     Ordination scores displayed.}
+
+  \item{pcol}{Colour of points or text.}
+
+  \item{col}{Colour of tree segments.}
+
+  \item{type}{Display of leaves: \code{"p"} for points, \code{"t"} for
+    item rownames of scores, and \code{"n"} for no display.}
 
   \item{\dots}{ Arguments passed to \code{\link[vegan]{scores}} and
     graphical functions.}


### PR DESCRIPTION
Suggests new functions `ordicluster3d` and `orglcluster` that display a 2D ordination on a plane and an `hclust` dendrogram over that plane.  `ordicluster3d` is a static plot based on **scatterplot3d** and `orglcluster` a dynamic spinnable plot based on **rgl**.