### PR TITLE
Change rgl.* to *3d calls

### DIFF
--- a/R/ordirgl.R
+++ b/R/ordirgl.R
@@ -8,7 +8,7 @@
     if (ncol(x) < 3) 
         stop("3D display needs three dimensions...")
     ## clear window and set isometric aspect ratio
-    rgl.clear()
+    clear3d()
     op <- aspect3d("iso")
     if (!all(op$scale == 1))
         warning("set isometric aspect ratio, previously was ",
@@ -26,21 +26,21 @@
         cex <- eval(match.call(expand.dots = FALSE)$...$cex)
         if (!is.null(cex))
             radius <- cex * radius
-        rgl.spheres(x, radius = radius, col = col,  ...)
+        spheres3d(x, radius = radius, col = col,  ...)
     }
     else if (type == "t") {
         if (missing(text)) 
             text <- rownames(x)
-        rgl.texts(x[, 1], x[, 2], x[, 3], text, adj = 0.5, col = col,  ...)
+        text3d(x[, 1], x[, 2], x[, 3], text, adj = 0.5, col = col,  ...)
     }
-    rgl.lines(range(x[, 1]), c(0, 0), c(0, 0), col = ax.col)
-    rgl.lines(c(0, 0), range(x[, 2]), c(0, 0), col = ax.col)
-    rgl.lines(c(0, 0), c(0, 0), range(x[, 3]), col = ax.col)
-    rgl.texts(1.1 * max(x[, 1]), 0, 0, colnames(x)[1], col = ax.col, 
+    segments3d(range(x[, 1]), c(0, 0), c(0, 0), col = ax.col)
+    segments3d(c(0, 0), range(x[, 2]), c(0, 0), col = ax.col)
+    segments3d(c(0, 0), c(0, 0), range(x[, 3]), col = ax.col)
+    text3d(1.1 * max(x[, 1]), 0, 0, colnames(x)[1], col = ax.col, 
               adj = 0.5)
-    rgl.texts(0, 1.1 * max(x[, 2]), 0, colnames(x)[2], col = ax.col, 
+    text3d(0, 1.1 * max(x[, 2]), 0, colnames(x)[2], col = ax.col, 
               adj = 0.5)
-    rgl.texts(0, 0, 1.1 * max(x[, 3]), colnames(x)[3], col = ax.col, 
+    text3d(0, 0, 1.1 * max(x[, 3]), colnames(x)[3], col = ax.col, 
               adj = 0.5)
     if (!missing(envfit) ||
         (is.list(object) && !is.null(object$CCA) && object$CCA$rank > 0)) {
@@ -52,9 +52,9 @@
         cn <- scores(object, dis = "cn", choices = choices)
         if (!is.null(cn) && !any(is.na(cn))) {
             bp <- bp[!(rownames(bp) %in% rownames(cn)), , drop = FALSE]
-            rgl.texts(cn[, 1], cn[, 2], cn[, 3], rownames(cn), 
+            text3d(cn[, 1], cn[, 2], cn[, 3], rownames(cn), 
                       col = arr.col, adj = 0.5)
-            rgl.points(cn[, 1], cn[, 2], cn[, 3], size = 5, col = arr.col)
+            points3d(cn[, 1], cn[, 2], cn[, 3], size = 5, col = arr.col)
         }
         if (!is.null(bp) && nrow(bp) > 0) {
             mul <- c(range(x[, 1]), range(x[, 2]), range(x[, 
@@ -64,9 +64,9 @@
             mul <- min(mul)
             bp <- bp * mul
             for (i in 1:nrow(bp)) {
-                rgl.lines(c(0, bp[i, 1]), c(0, bp[i, 2]), c(0, 
+                segments3d(c(0, bp[i, 1]), c(0, bp[i, 2]), c(0, 
                                                             bp[i, 3]), col = arr.col)
-                rgl.texts(1.1 * bp[i, 1], 1.1 * bp[i, 2], 1.1 * 
+                text3d(1.1 * bp[i, 1], 1.1 * bp[i, 2], 1.1 * 
                           bp[i, 3], rownames(bp)[i], col = arr.col,
                           adj = 0.5)
             }

--- a/R/orditree3d.R
+++ b/R/orditree3d.R
@@ -82,30 +82,30 @@
     b <- reorder(cluster, lcol[3,], agglo.FUN = "mean")$value
     lcol <- rgb(r, g, b)
     ## plot
-    rgl.clear()
+    clear3d()
     if (type == "p")
-        rgl.points(p, col = col, ...)
+        points3d(p, col = col, ...)
     else if (type == "t") {
         if (missing(text))
             text <- rownames(p)
-        rgl.texts(p, text = text, col = col, ...)
+        text3d(p, text = text, col = col, ...)
     }
     for (i in seq_len(nrow(merge) - prune))
         for(j in 1:2)
             if (merge[i,j] < 0)
-                rgl.lines(c(x[i], p[-merge[i,j],1]),
+                segments3d(c(x[i], p[-merge[i,j],1]),
                           c(y[i], p[-merge[i,j],2]),
                           c(z[i], 0),
                           col = col[-merge[i,j]], ...)
             else
-                rgl.lines(c(x[i], x[merge[i,j]]),
+                segments3d(c(x[i], x[merge[i,j]]),
                           c(y[i], y[merge[i,j]]),
                           c(z[i], z[merge[i,j]]),
                           col = lcol[merge[i,j]], ...)
     ## add a short nipple so that you see the root (if you draw the root)
     if (prune <= 0) {
         n <- nrow(merge)
-        rgl.lines(c(x[n],x[n]), c(y[n],y[n]), c(z[n],1.05*z[n]),
+        segments3d(c(x[n],x[n]), c(y[n],y[n]), c(z[n],1.05*z[n]),
                   col = lcol[n], ...)
     }
 }

--- a/R/orglpoints.R
+++ b/R/orglpoints.R
@@ -14,7 +14,7 @@
     if (is.factor(col))
         col <- as.numeric(col)
     col <- rep(col, length = nrow(x))
-    rgl.spheres(x, radius = radius, col = col, ...)
+    spheres3d(x, radius = radius, col = col, ...)
     invisible()
 }
 

--- a/R/orglsegments.R
+++ b/R/orglsegments.R
@@ -21,7 +21,7 @@
         X <- pts[groups == is, , drop = FALSE]
         if (nrow(X) > 1) {
             for (i in 2:nrow(X)) {
-                rgl.lines(c(X[i-1,1],X[i,1]), c(X[i-1,2],X[i,2]), 
+                segments3d(c(X[i-1,1],X[i,1]), c(X[i-1,2],X[i,2]), 
                           c(X[i-1,3],X[i,3]), col = col[is], ...)
             }
         }

--- a/R/orglspantree.R
+++ b/R/orglspantree.R
@@ -20,7 +20,7 @@
         one <- x[i+1,]
         two <- x[k[i],]
         lcol <- rgb(t(col[, i+1] + col[,k[i]])/2)
-        rgl.lines(rbind(one, two), col = lcol, ...)
+        segments3d(rbind(one, two), col = lcol, ...)
     }
 }
 
@@ -54,6 +54,6 @@
             two <- x[-merge[i,2],]
         else
             two <- node[merge[i,2],]
-        rgl.lines(rbind(one, two), col = nodecol[i], ...)
+        segments3d(rbind(one, two), col = nodecol[i], ...)
     }
 }

--- a/R/orglspider.R
+++ b/R/orglspider.R
@@ -8,7 +8,7 @@
         wa <- scores(object, display = "wa", choices = choices, ...)
         if (length(lc) == 0 || length(wa) == 0)
             stop("needs constrained ordination with WA and LC scores when 'groups' is missing")
-        for (i in 1:nrow(lc)) rgl.lines(c(lc[i, 1], wa[i, 1]), 
+        for (i in 1:nrow(lc)) segments3d(c(lc[i, 1], wa[i, 1]), 
                                         c(lc[i, 2], wa[i, 2]),
                                         c(lc[i, 3], wa[i, 3]),
                                         color = col, ...)
@@ -33,7 +33,7 @@
                 W <- w[gr]
                 ave <- apply(X, 2, weighted.mean, w = W)
                 for (i in 1:length(gr))
-                    rgl.lines(c(ave[1], X[i,1]), c(ave[2], X[i, 2]),
+                    segments3d(c(ave[1], X[i,1]), c(ave[2], X[i, 2]),
                               c(ave[3], X[i, 3]),  col = col[is], ...)
             }
         }

--- a/R/orgltext.R
+++ b/R/orgltext.R
@@ -10,6 +10,6 @@
     if (is.factor(col))
         col <- as.numeric(col)
     col <- rep(col, length = nrow(x))
-    rgl.texts(x[, 1], x[, 2], x[, 3], text, adj = adj,  col = col, ...)
+    text3d(x[, 1], x[, 2], x[, 3], text, adj = adj,  col = col, ...)
     invisible()
 }

--- a/R/rgl.isomap.R
+++ b/R/rgl.isomap.R
@@ -15,7 +15,7 @@
         web <- col2rgb(web)/255
         for (i in 1:nrow(net)) {
             lcol <- rgb(t(rowMeans(web[, net[i,]])))
-            rgl.lines(z[net[i,],1], z[net[i,],2], z[net[i,],3], color=lcol)
+            segments3d(z[net[i,],1], z[net[i,],2], z[net[i,],3], color=lcol)
         }
     }
 }

--- a/R/rgl.renyiaccum.R
+++ b/R/rgl.renyiaccum.R
@@ -12,22 +12,22 @@
     ylen <- ylim[2] - ylim[1] + 1
     colorlut <- rainbow(ylen)
     col <- colorlut[1000*y-ylim[1]+1]
-    rgl.clear()
-    ## rgl.bg(color = "white")
-    rgl.surface(xp, z, y, color=col)
+    clear3d()
+    ## bg3d(color = "white")
+    surface3d(xp, y, z, color=col)
     y <- x[,,5] * rgl.height
-    ##rgl.surface(xp,z,y,color="grey", alpha=0.3)
-    rgl.surface(xp, z, y,  color="black", front="lines", back="lines")
+    ##surface3d(xp,y,z,color="grey", alpha=0.3)
+    surface3d(xp, y, z, color="black", front="lines", back="lines")
     y <- x[,,6] * rgl.height
-    ##rgl.surface(xp,z,y,color="grey",alpha=0.3)
-    rgl.surface(xp, z, y, color="black", front="lines", back="lines")
+    ##surface3d(xp,y,z,color="grey",alpha=0.3)
+    surface3d(xp, y, z, color="black", front="lines", back="lines")
     y <- x[,,6]*0 + rgl.min
-    rgl.surface(xp, z, y, alpha=0)
+    surface3d(xp, y, z, alpha=0)
     y <- x[,,6] * 0 + rgl.max
-    rgl.surface(xp, z, y, alpha=0)
+    surface3d(xp, y, z, alpha=0)
     labs <- pretty(c(rgl.min, range(x)))
-    rgl.bbox(color="#333377", emission="#333377", specular="#3333FF", shininess=5, alpha=0.8,
+    bbox3d(color="#333377", emission="#333377", specular="#3333FF", shininess=5, alpha=0.8,
              zlen=0, xlen=0, yat = rgl.height*labs, ylab=labs) 
-    rgl.texts(0, rgl.min, 0.5, "Scale", col = "darkblue")
-    rgl.texts(0.5, rgl.min, 0, "Sites", col="darkblue")
+    text3d(0, rgl.min, 0.5, "Scale", col = "darkblue")
+    text3d(0.5, rgl.min, 0, "Sites", col="darkblue")
 }

--- a/man/ordirgl.Rd
+++ b/man/ordirgl.Rd
@@ -53,7 +53,7 @@ orglcluster(object, cluster, prune = 0, display = "sites", choices = 1:3,
   \item{envfit}{Fitted environmental variables from \code{\link{envfit}}
     displayed in the graph. Use \code{envfit = NA} to suppress display
     of environmental variables in constrained ordination.}
-  \item{adj}{Text justification passed to \code{\link[rgl]{rgl.texts}}.}
+  \item{adj}{Text justification passed to \code{\link[rgl]{text3d}}.}
   \item{groups}{Factor giving the groups for which the graphical item is
     drawn.}
   \item{order.by}{Order points by this variable within \code{groups}.}
@@ -97,12 +97,12 @@ orglcluster(object, cluster, prune = 0, display = "sites", choices = 1:3,
   graphical functions in \code{rgl}. It plots only one set of points,
   but functions \code{orglpoints} and \code{orgltext} can add new
   items to an existing plot. The points are plotted using
-  \code{\link[rgl]{rgl.spheres}} and the text using
-  \code{\link[rgl]{rgl.texts}} which both have their own configuration
+  \code{\link[rgl]{spheres3d}} and the text using
+  \code{\link[rgl]{texts3d}} which both have their own configuration
   switches and their general look and feel can be modified with
-  \code{\link[rgl]{rgl.material}}. The point size is directly defined
+  \code{\link[rgl]{material3d}}. The point size is directly defined
   by \code{radius} argument in the units of ordination scores in
-  \code{\link[rgl]{rgl.spheres}}, but \code{ordirgl} uses a default
+  \code{\link[rgl]{spheres3d}}, but \code{ordirgl} uses a default
   size of 1\% of the length of the longest axis, and this can be
   further modified by the \code{cex} multiplier.
 
@@ -165,8 +165,8 @@ orglcluster(object, cluster, prune = 0, display = "sites", choices = 1:3,
 
 \seealso{
 
-  \code{\link[rgl]{rgl}}, \code{\link[rgl]{rgl.spheres}},
-  \code{\link[rgl]{rgl.texts}}, \code{\link[rgl]{rgl.viewpoint}},
+  \code{\link[rgl]{rgl}}, \code{\link[rgl]{spheres3d}},
+  \code{\link[rgl]{text3d}}, \code{\link[rgl]{rgl.viewpoint}},
   \code{\link[vegan]{envfit}}. These are 3D dynamic variants of
   \CRANpkg{vegan} functions \code{\link[vegan]{ordiplot}},
   \code{\link[vegan]{ordisegments}}, \code{\link[vegan]{ordispider}}

--- a/man/orditree3d.Rd
+++ b/man/orditree3d.Rd
@@ -94,7 +94,7 @@ ordirgltree(ord, cluster, prune = 0, display = "sites", choices = c(1, 2),
   cl <- hclust(d, "aver")
   orditree3d(m, cl, pch=16, col=cutree(cl, 3))
   ## ordirgltree makes ordinary rgl graphics. It accepts
-  ## rgl.material() settings, and you can add elements to the
+  ## material3d() settings, and you can add elements to the
   ## open graph (for instance, bbox3d()).
   if (interactive() && require(rgl, quietly = TRUE)) {
   with(dune.env, ordirgltree(m, cl, col = as.numeric(Management), size = 6,

--- a/man/vegan3d-package.Rd
+++ b/man/vegan3d-package.Rd
@@ -27,7 +27,7 @@ ordination and clustering objects. The functions use \CRANpkg{rgl} setting
 and conventions and do not change the user settings. For general
 configuration of the plots, users should check \pkg{\link{rgl}}
 documentation. For instance, general look and feel of drawn items can
-be configured with \code{\link[rgl]{rgl.material}}.
+be configured with \code{\link[rgl]{material3d}}.
 
 The \CRANpkg{rgl} package may not be available in all platforms, and
 therefore the package is not automatically attached. If you want to


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to vegan3d.
I will be deprecating a number of rgl.* function calls.  You can read
about the issues here:

    https://dmurdoch.github.io/rgl/articles/deprecation.html

I worked out changes for your package, which are in the attached PR.  The plots should show the same information, but default colors and projections may have changed.